### PR TITLE
Update arrow edit factor handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -142,16 +142,20 @@ const App = () => {
             }
             return updatedAnchors;
         });
-        if (currentAnchors.length + 1 <= 2) {
+        const newCount = currentAnchors.length + 1;
+        if (newCount <= 2) {
             resetCurrentPixelValues();
-            if (currentAnchors.length + 1 === 2) {
+            if (newCount === 2) {
                 setCurrentShaftThicknessFactor(DEFAULT_SHAFT_THICKNESS_FACTOR);
                 setCurrentArrowHeadLengthFactor(DEFAULT_ARROW_HEAD_LENGTH_FACTOR);
                 setCurrentArrowHeadWidthFactor(DEFAULT_ARROW_HEAD_WIDTH_FACTOR);
+                updatePixelValuesFromFactors();
             }
         }
-        updatePixelValuesFromFactors();
-    }, [currentAnchors.length, resetCurrentPixelValues, updatePixelValuesFromFactors]);
+        else {
+            updateFactorsFromPixelValues();
+        }
+    }, [currentAnchors.length, resetCurrentPixelValues, updatePixelValuesFromFactors, updateFactorsFromPixelValues]);
     const onArrowDrag = useCallback((e) => {
         const map = mapRef.current;
         if (!isArrowDraggingRef.current || !map || !arrowDragStartPointRef.current)
@@ -193,8 +197,8 @@ const App = () => {
         map.off('mouseup', stopArrowDrag);
         map.dragging.enable();
         map.getContainer().style.cursor = (editingState === EditingState.DrawingNew) ? "crosshair" : "default";
-        updatePixelValuesFromFactors();
-    }, [editingState, onArrowDrag, updatePixelValuesFromFactors]);
+        updateFactorsFromPixelValues();
+    }, [editingState, onArrowDrag, updateFactorsFromPixelValues]);
     const startArrowDrag = useCallback((e) => {
         const map = mapRef.current;
         if (!map || currentAnchors.length < 1 || editingState === EditingState.Idle)
@@ -336,8 +340,8 @@ const App = () => {
             }
             return newAnchors;
         });
-        updatePixelValuesFromFactors();
-    }, [resetCurrentPixelValues, updatePixelValuesFromFactors]);
+        updateFactorsFromPixelValues();
+    }, [resetCurrentPixelValues, updateFactorsFromPixelValues]);
     const handleGenericDragStart = useCallback((e) => {
         mapRef.current?.dragging.disable();
         if (e.originalEvent)
@@ -347,8 +351,8 @@ const App = () => {
         mapRef.current?.dragging.enable();
         if (e.originalEvent)
             L.DomEvent.stopPropagation(e.originalEvent);
-        updatePixelValuesFromFactors();
-    }, [updatePixelValuesFromFactors]);
+        updateFactorsFromPixelValues();
+    }, [updateFactorsFromPixelValues]);
     const handleAnchorDragStart = useCallback((e, anchorId) => {
         handleGenericDragStart(e);
         const anchor = currentAnchors.find(a => a.id === anchorId);

--- a/App.tsx
+++ b/App.tsx
@@ -167,16 +167,20 @@ const App: React.FC = () => {
         return updatedAnchors;
     });
 
-    if (currentAnchors.length + 1 <= 2) { 
+    const newCount = currentAnchors.length + 1;
+
+    if (newCount <= 2) {
       resetCurrentPixelValues();
-      if (currentAnchors.length + 1 === 2) { 
+      if (newCount === 2) {
         setCurrentShaftThicknessFactor(DEFAULT_SHAFT_THICKNESS_FACTOR);
         setCurrentArrowHeadLengthFactor(DEFAULT_ARROW_HEAD_LENGTH_FACTOR);
         setCurrentArrowHeadWidthFactor(DEFAULT_ARROW_HEAD_WIDTH_FACTOR);
+        updatePixelValuesFromFactors();
       }
+    } else {
+      updateFactorsFromPixelValues();
     }
-    updatePixelValuesFromFactors(); 
-  }, [currentAnchors.length, resetCurrentPixelValues, updatePixelValuesFromFactors]); 
+  }, [currentAnchors.length, resetCurrentPixelValues, updatePixelValuesFromFactors, updateFactorsFromPixelValues]);
 
   const onArrowDrag = useCallback((e: L.LeafletMouseEvent) => {
     const map = mapRef.current;
@@ -218,8 +222,8 @@ const App: React.FC = () => {
     map.off('mouseup', stopArrowDrag);
     map.dragging.enable();
     map.getContainer().style.cursor = (editingState === EditingState.DrawingNew) ? "crosshair" : "default";
-    updatePixelValuesFromFactors(); 
-  }, [editingState, onArrowDrag, updatePixelValuesFromFactors]);
+    updateFactorsFromPixelValues();
+  }, [editingState, onArrowDrag, updateFactorsFromPixelValues]);
 
   const startArrowDrag = useCallback((e: L.LeafletMouseEvent) => {
     const map = mapRef.current;
@@ -374,8 +378,8 @@ const App: React.FC = () => {
         }
         return newAnchors;
     });
-    updatePixelValuesFromFactors();
-  }, [resetCurrentPixelValues, updatePixelValuesFromFactors]);
+    updateFactorsFromPixelValues();
+  }, [resetCurrentPixelValues, updateFactorsFromPixelValues]);
   
   const handleGenericDragStart = useCallback((e: L.LeafletEvent) => {
     mapRef.current?.dragging.disable();
@@ -385,8 +389,8 @@ const App: React.FC = () => {
   const handleGenericDragEnd = useCallback((e: L.LeafletEvent) => {
     mapRef.current?.dragging.enable();
     if ((e as L.LeafletMouseEvent).originalEvent) L.DomEvent.stopPropagation((e as L.LeafletMouseEvent).originalEvent);
-    updatePixelValuesFromFactors(); 
-  }, [updatePixelValuesFromFactors]);
+    updateFactorsFromPixelValues();
+  }, [updateFactorsFromPixelValues]);
 
   const handleAnchorDragStart = useCallback((e: L.LeafletEvent, anchorId: string) => {
     handleGenericDragStart(e);


### PR DESCRIPTION
## Summary
- keep pixel values constant when editing arrows by adjusting factors
- only compute pixel values on creation when the second anchor is added

## Testing
- `node build.cjs` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6849e9c5335c83258b9f84ea9575996a