### PR TITLE
Fix arrow head slider cross-effect

### DIFF
--- a/App.js
+++ b/App.js
@@ -95,13 +95,19 @@ const App = () => {
 
     const handleArrowHeadLengthChange = useCallback((factor) => {
         setCurrentArrowHeadLengthFactor(factor);
-        updatePixelValuesFromFactors();
-    }, [updatePixelValuesFromFactors]);
+        if (mapRef.current && currentAnchors.length >= 2) {
+            const { totalLength } = getValidPointsAndLength(mapRef.current, getAnchorsData());
+            setCurrentArrowHeadLengthPixels(totalLength > 1e-6 ? totalLength * factor : 0);
+        }
+    }, [getAnchorsData, currentAnchors.length]);
 
     const handleArrowHeadWidthChange = useCallback((factor) => {
         setCurrentArrowHeadWidthFactor(factor);
-        updatePixelValuesFromFactors();
-    }, [updatePixelValuesFromFactors]);
+        if (mapRef.current && currentAnchors.length >= 2) {
+            const { totalLength } = getValidPointsAndLength(mapRef.current, getAnchorsData());
+            setCurrentArrowHeadWidthPixels(totalLength > 1e-6 ? totalLength * factor : 0);
+        }
+    }, [getAnchorsData, currentAnchors.length]);
     const resetCurrentPixelValues = useCallback(() => {
         setCurrentShaftThicknessPixels(null);
         setCurrentArrowHeadLengthPixels(null);

--- a/App.tsx
+++ b/App.tsx
@@ -114,13 +114,19 @@ const App: React.FC = () => {
 
   const handleArrowHeadLengthChange = useCallback((factor: number) => {
     setCurrentArrowHeadLengthFactor(factor);
-    updatePixelValuesFromFactors();
-  }, [updatePixelValuesFromFactors]);
+    if (mapRef.current && currentAnchors.length >= 2) {
+      const { totalLength } = getValidPointsAndLength(mapRef.current, getAnchorsData());
+      setCurrentArrowHeadLengthPixels(totalLength > 1e-6 ? totalLength * factor : 0);
+    }
+  }, [getAnchorsData, currentAnchors.length]);
 
   const handleArrowHeadWidthChange = useCallback((factor: number) => {
     setCurrentArrowHeadWidthFactor(factor);
-    updatePixelValuesFromFactors();
-  }, [updatePixelValuesFromFactors]);
+    if (mapRef.current && currentAnchors.length >= 2) {
+      const { totalLength } = getValidPointsAndLength(mapRef.current, getAnchorsData());
+      setCurrentArrowHeadWidthPixels(totalLength > 1e-6 ? totalLength * factor : 0);
+    }
+  }, [getAnchorsData, currentAnchors.length]);
 
   const resetCurrentPixelValues = useCallback(() => {
     setCurrentShaftThicknessPixels(null);


### PR DESCRIPTION
## Summary
- adjust handlers to only update arrow head pixel values when sliders change
- do not recompute shaft thickness when modifying arrow head parameters

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630145045483258102f290f117ddee