### PR TITLE
Fix missing constant import

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import L from 'leaflet';
 import { EditingState } from './types.js';
 import ControlPanel from './components/ControlPanel.js';
-import { DEFAULT_SHAFT_THICKNESS_FACTOR, DEFAULT_ARROW_HEAD_LENGTH_FACTOR, DEFAULT_ARROW_HEAD_WIDTH_FACTOR, anchorIcon, handleIcon, HANDLE_OFFSET_ON_LINE_PIXELS, INITIAL_MAP_CENTER, INITIAL_MAP_ZOOM } from './constants.js';
+import { DEFAULT_SHAFT_THICKNESS_FACTOR, DEFAULT_TAIL_THICKNESS_FACTOR, DEFAULT_ARROW_HEAD_LENGTH_FACTOR, DEFAULT_ARROW_HEAD_WIDTH_FACTOR, anchorIcon, handleIcon, HANDLE_OFFSET_ON_LINE_PIXELS, INITIAL_MAP_CENTER, INITIAL_MAP_ZOOM } from './constants.js';
 import { pointSubtract, pointAdd, pointMultiply, pointLength, normalize, perpendicular, getValidPointsAndLength, calculateArrowOutlinePoints } from './utils/geometry.js';
 const App = () => {
     const mapContainerRef = useRef(null);

--- a/App.tsx
+++ b/App.tsx
@@ -4,9 +4,16 @@ import L from 'leaflet';
 import type { Anchor, AnchorData, ArrowGroup, ArrowParameters, EditingState as EditingStateType, GeoJsonFeature, GeoJsonFeatureCollection, LatLngLiteral, Point as GeomPoint, SavedArrowProperties } from './types';
 import { EditingState } from './types';
 import ControlPanel from './components/ControlPanel';
-import { 
-  DEFAULT_SHAFT_THICKNESS_FACTOR, DEFAULT_ARROW_HEAD_LENGTH_FACTOR, DEFAULT_ARROW_HEAD_WIDTH_FACTOR, 
-  anchorIcon, handleIcon, HANDLE_OFFSET_ON_LINE_PIXELS, INITIAL_MAP_CENTER, INITIAL_MAP_ZOOM
+import {
+  DEFAULT_SHAFT_THICKNESS_FACTOR,
+  DEFAULT_TAIL_THICKNESS_FACTOR,
+  DEFAULT_ARROW_HEAD_LENGTH_FACTOR,
+  DEFAULT_ARROW_HEAD_WIDTH_FACTOR,
+  anchorIcon,
+  handleIcon,
+  HANDLE_OFFSET_ON_LINE_PIXELS,
+  INITIAL_MAP_CENTER,
+  INITIAL_MAP_ZOOM
 } from './constants';
 import { 
   pointSubtract, pointAdd, pointMultiply, pointLength, normalize, perpendicular, 


### PR DESCRIPTION
## Summary
- import DEFAULT_TAIL_THICKNESS_FACTOR in `App.js` and `App.tsx`

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686c3bd7beb883259a30011e478d5416