### PR TITLE
Introduce source structure with build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Run and deploy your AI Studio app
 
-This project is maintained entirely in plain JavaScript. The compiled `.js` files
-are committed to the repository so there is no build step required when
-deploying.
+Source files now live under `src/` and are compiled using Vite. The generated
+JavaScript in the repository root can still be served directly on GitHub Pages.
 
 ## Run Locally
 
 **Prerequisites:** Node.js
 
-1. Install dependencies (optional for development only): `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app locally (using Vite): `npm run dev`
+1. Install dependencies: `npm install`
+2. Build the compiled files: `npm run build`
+3. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+4. Run the app locally (using Vite): `npm run dev`
 
 Using Vite or another tool for local development is optional. Deployment only
 requires serving the files in this repository as-is.
 
 ## GitHub Pages
 
-Compiled JavaScript files (`*.js`) are included in the repository so the app can
-be served directly from GitHub Pages without a build step. Simply enable Pages
-for the repository and point it at the root directory.
+The compiled JavaScript files are checked in so the app can be hosted directly
+from the repository root. After editing the sources run `npm run build` and
+commit the updated files before pushing to GitHub Pages.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "leaflet": "^1.9.4"
   },
   "devDependencies": {
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "@vitejs/plugin-react": "^4.1.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import ControlPanel from './components/ControlPanel.jsx';
+import ArrowMap from './components/ArrowMap.jsx';
+import useArrowEditing from './hooks/useArrowEditing.js';
+import { arrowsToGeoJSON } from './utils/export.js';
+
+function App() {
+  const {
+    editingState,
+    anchors,
+    arrows,
+    startDrawing,
+    addPoint,
+    confirm,
+    cancel,
+  } = useArrowEditing();
+
+  const handleExport = () => {
+    const geo = arrowsToGeoJSON(arrows);
+    navigator.clipboard
+      .writeText(JSON.stringify(geo, null, 2))
+      .then(() => alert('GeoJSON copied to clipboard!'))
+      .catch(() => alert('Failed to copy GeoJSON'));
+  };
+
+  return (
+    <div className="relative h-full w-full flex">
+      <ArrowMap
+        anchors={anchors}
+        arrows={arrows}
+        editingState={editingState}
+        addPoint={addPoint}
+      />
+      <ControlPanel
+        editingState={editingState}
+        startDrawing={startDrawing}
+        confirm={confirm}
+        cancel={cancel}
+        onExport={handleExport}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/ArrowMap.jsx
+++ b/src/components/ArrowMap.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import { INITIAL_MAP_CENTER, INITIAL_MAP_ZOOM } from '../constants.js';
+import { EditingState } from '../types.js';
+
+export default function ArrowMap({ anchors, arrows, editingState, addPoint }) {
+  const mapRef = useRef(null);
+  const drawingLayerRef = useRef(null);
+  const arrowLayerRef = useRef(null);
+
+  useEffect(() => {
+    const map = L.map('map').setView(INITIAL_MAP_CENTER, INITIAL_MAP_ZOOM);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '© OpenStreetMap contributors',
+    }).addTo(map);
+    mapRef.current = map;
+    drawingLayerRef.current = L.layerGroup().addTo(map);
+    arrowLayerRef.current = L.layerGroup().addTo(map);
+    return () => map.remove();
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const handleClick = (e) => {
+      if (editingState === EditingState.DrawingNew) {
+        addPoint(e.latlng);
+      }
+    };
+    map.on('click', handleClick);
+    return () => map.off('click', handleClick);
+  }, [editingState, addPoint]);
+
+  useEffect(() => {
+    const layer = drawingLayerRef.current;
+    if (!layer) return;
+    layer.clearLayers();
+    if (anchors.length > 0) {
+      L.polyline(anchors, { color: 'red' }).addTo(layer);
+    }
+  }, [anchors]);
+
+  useEffect(() => {
+    const layer = arrowLayerRef.current;
+    if (!layer) return;
+    layer.clearLayers();
+    arrows.forEach((arrow) => {
+      L.polyline(arrow.points, { color: 'blue' }).addTo(layer);
+    });
+  }, [arrows]);
+
+  return <div id="map" className="h-full w-full grow"></div>;
+}

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { EditingState } from '../types.js';
+
+export default function ControlPanel({
+  editingState,
+  startDrawing,
+  confirm,
+  cancel,
+  onExport,
+}) {
+  const drawing = editingState === EditingState.DrawingNew;
+
+  return (
+    <div
+      id="controlPanel"
+      className="absolute top-4 right-4 z-[10000] bg-white p-4 border border-gray-300 rounded-lg shadow-lg w-48 flex flex-col gap-2"
+    >
+      {!drawing && (
+        <button
+          onClick={startDrawing}
+          className="px-3 py-2 bg-blue-500 text-white rounded"
+        >
+          Draw Arrow
+        </button>
+      )}
+      {drawing && (
+        <>
+          <button
+            onClick={confirm}
+            className="px-3 py-2 bg-green-500 text-white rounded"
+          >
+            Confirm
+          </button>
+          <button onClick={cancel} className="px-3 py-2 bg-gray-200 rounded">
+            Cancel
+          </button>
+        </>
+      )}
+      <button onClick={onExport} className="px-3 py-2 bg-slate-200 rounded">
+        Export GeoJSON
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useArrowEditing.js
+++ b/src/hooks/useArrowEditing.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { EditingState } from '../types.js';
+
+export default function useArrowEditing() {
+  const [editingState, setEditingState] = useState(EditingState.Idle);
+  const [anchors, setAnchors] = useState([]);
+  const [arrows, setArrows] = useState([]);
+
+  const startDrawing = () => {
+    setAnchors([]);
+    setEditingState(EditingState.DrawingNew);
+  };
+
+  const addPoint = (latlng) => {
+    setAnchors((prev) => [...prev, latlng]);
+  };
+
+  const confirm = () => {
+    if (anchors.length >= 2) {
+      setArrows((prev) => [...prev, { id: Date.now(), points: anchors }]);
+    }
+    setAnchors([]);
+    setEditingState(EditingState.Idle);
+  };
+
+  const cancel = () => {
+    setAnchors([]);
+    setEditingState(EditingState.Idle);
+  };
+
+  const deleteArrow = (id) => {
+    setArrows((prev) => prev.filter((a) => a.id !== id));
+  };
+
+  return {
+    editingState,
+    anchors,
+    arrows,
+    startDrawing,
+    addPoint,
+    confirm,
+    cancel,
+    deleteArrow,
+  };
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -1,0 +1,11 @@
+export function arrowsToGeoJSON(arrows) {
+  const features = arrows.map((a) => ({
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: a.points.map((p) => [p.lng, p.lat]),
+    },
+    properties: { id: a.id },
+  }));
+  return { type: 'FeatureCollection', features };
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: '.',
+    emptyOutDir: false,
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'src/index.jsx'),
+      },
+      output: {
+        entryFileNames: 'index.js',
+        format: 'es',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add new React source tree in `src/`
- implement simplified arrow editing via custom hook
- move map logic to `ArrowMap` component
- expose GeoJSON export helper
- add Vite build configuration
- document build step

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687562a0cd108325bb5f8b4faf921268