### PR TITLE
Fix missing constants and deployment script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,6 @@
 </head>
 <body>
     <div id="root" class="h-full w-full"></div>
-    <script type="module" src="./dist/index.js"></script>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,21 @@
+import L from 'leaflet';
+export const DEFAULT_SHAFT_THICKNESS_FACTOR = 0.05;
+export const DEFAULT_ARROW_HEAD_LENGTH_FACTOR = 0.125;
+export const DEFAULT_ARROW_HEAD_WIDTH_FACTOR = 0.125;
+export const HANDLE_OFFSET_ON_LINE_PIXELS = 30;
+export const ANCHOR_ICON_HTML = '<div style="width:12px;height:12px;border-radius:6px;background:red;border:2px solid white;box-shadow: 0 0 3px rgba(0,0,0,0.5);"></div>';
+export const HANDLE_ICON_HTML = '<div style="width:10px;height:10px;border-radius:5px;background:blue;border:1px solid white;box-shadow: 0 0 3px rgba(0,0,0,0.5);"></div>';
+export const anchorIcon = L.divIcon({
+    html: ANCHOR_ICON_HTML,
+    className: 'leaflet-div-icon anchor-icon',
+    iconSize: [12, 12],
+    iconAnchor: [6, 6],
+});
+export const handleIcon = L.divIcon({
+    html: HANDLE_ICON_HTML,
+    className: 'leaflet-div-icon handle-icon',
+    iconSize: [10, 10],
+    iconAnchor: [5, 5],
+});
+export const INITIAL_MAP_CENTER = [51.1657, 10.4515];
+export const INITIAL_MAP_ZOOM = 6;

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,6 @@
+export var EditingState;
+(function (EditingState) {
+    EditingState[EditingState["Idle"] = 0] = "Idle";
+    EditingState[EditingState["DrawingNew"] = 1] = "DrawingNew";
+    EditingState[EditingState["EditingSelected"] = 2] = "EditingSelected";
+})(EditingState || (EditingState = {}));


### PR DESCRIPTION
## Summary
- restore removed `constants.js` and `types.js` to satisfy imports
- reference built JS correctly in `index.html`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687578567c948325821417075df5ca20